### PR TITLE
Make loading screen image smaller

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
 <body id="homepage">
   <div id="loader">
     <div class="stat">
-      <img src="/images/logo/mecdev.svg" alt="IEEEMEC-center">
+      <img src="/images/logo/mecdev.svg" alt="IEEEMEC-center" style="max-height: 200px; max-width: 200px">
     </div>
   </div>
 


### PR DESCRIPTION
Now not only does the lower quality of the SVG logo become unnoticeable, it looks nicer overall.